### PR TITLE
Enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,4 @@ path = "src/storage_read.rs"
 
 [profile.release]
 panic = "abort"
+lto = true


### PR DESCRIPTION
After this change all tests should consume less gas, be a little lighter in size.